### PR TITLE
Prismクラスタ名の指定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Terraform をインストールして、任意のディレクトリで実行し�
 - prov_username = "admin" : PRISMにログインするユーザー名を入力します。
 - prov_password = "nutanix/4u" : 上記ユーザーに対応するパスワードを入力します。
 - prov_endpoint = "0.0.0.0" : PRISMのクラスターIPまたはFQDNを入力します。
+- prov_cluster_name = "AHV" : PRISMのクラスター名を入力します。
 - prov_vmname_prefix = "tfvm" : 仮想マシンの接頭語を入力します。
 - prov_num = "2" : 展開したい台数を入力します。
 - prov_subnet_uuid = "7ebac8b7-b6e9-4cda-8956-ee9e100XXXXX" : 展開対象の仮想マシンのネットワークを指定します。

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@
   variable "prov_username" {}
   variable "prov_password" {}
   variable "prov_endpoint" {}
+  variable "prov_cluster_name" {}
   variable "prov_vmname_prefix" {}
   variable "prov_num" {}
   variable "prov_subnet_uuid" {}
@@ -23,7 +24,7 @@ data "nutanix_clusters" "clusters" {}
 locals {
 	prov_cluster = [
 	for cluster in data.nutanix_clusters.clusters.entities :
-	cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+        cluster if cluster.name == var.prov_cluster_name
 	][0]
 }
 
@@ -37,7 +38,7 @@ resource "nutanix_virtual_machine" "nutanix_virtual_machine"{
   memory_size_mib      = var.prov_mem
 
   # Configure Cluster
-  cluster_uuid = local.prov_cluster
+  cluster_uuid = local.prov_cluster.metadata.uuid
 
   # Configure Network   
   nic_list {

--- a/main.tf
+++ b/main.tf
@@ -20,12 +20,8 @@ provider "nutanix" {
   port      = 9440
 }
 
-data "nutanix_clusters" "clusters" {}
-locals {
-	prov_cluster = [
-	for cluster in data.nutanix_clusters.clusters.entities :
-        cluster if cluster.name == var.prov_cluster_name
-	][0]
+data "nutanix_cluster" "cluster" {
+  name = var.prov_cluster_name
 }
 
 resource "nutanix_virtual_machine" "nutanix_virtual_machine"{
@@ -38,7 +34,7 @@ resource "nutanix_virtual_machine" "nutanix_virtual_machine"{
   memory_size_mib      = var.prov_mem
 
   # Configure Cluster
-  cluster_uuid = local.prov_cluster.metadata.uuid
+  cluster_uuid = data.nutanix_cluster.cluster.metadata.uuid
 
   # Configure Network   
   nic_list {

--- a/terraform.auto.tfvars
+++ b/terraform.auto.tfvars
@@ -1,6 +1,7 @@
 prov_username = "admin"
 prov_password = "nutanix/4u"
 prov_endpoint = "0.0.0.0"
+prov_cluster_name   = "AHV"
 prov_vmname_prefix = "tfvm"
 prov_num = "2"
 prov_subnet_uuid = "7ebac8b7-b6e9-4cda-8956-ee9e100XXXXX"

--- a/terraform.auto.tfvars
+++ b/terraform.auto.tfvars
@@ -1,7 +1,7 @@
 prov_username = "admin"
 prov_password = "nutanix/4u"
 prov_endpoint = "0.0.0.0"
-prov_cluster_name   = "AHV"
+prov_cluster_name = "AHV"
 prov_vmname_prefix = "tfvm"
 prov_num = "2"
 prov_subnet_uuid = "7ebac8b7-b6e9-4cda-8956-ee9e100XXXXX"


### PR DESCRIPTION
Prism Central 接続でも利用できるように、Prismクラスタ名を指定できるようにしてみました。